### PR TITLE
Use explicit definition of whitespace

### DIFF
--- a/src/css/TokenStream.js
+++ b/src/css/TokenStream.js
@@ -1,8 +1,8 @@
 
-
 var h = /^[0-9a-fA-F]$/,
     nonascii = /^[\u0080-\uFFFF]$/,
-    nl = /\n|\r\n|\r|\f/;
+    nl = /\n|\r\n|\r|\f/,
+    whitespace = /\u0009|\u000a|\u000c|\u000d|\u0020/;
 
 //-----------------------------------------------------------------------------
 // Helper functions
@@ -18,7 +18,7 @@ function isDigit(c){
 }
 
 function isWhitespace(c){
-    return c != null && /\s/.test(c);
+    return c != null && whitespace.test(c);
 }
 
 function isNewLine(c){


### PR DESCRIPTION
`/\s/` regular expression can be interpreted in different ways depending on user agent. For example in Firefox `/\s/` is equivelant to `[ \f\n\r\t\v​\u00A0\u1680​\u180e\u2000​\u2001\u2002​\u2003\u2004​\u2005\u2006​\u2007\u2008​\u2009\u200a​\u2028\u2029​\u2028\u2029​\u202f\u205f​\u3000]`

CSS3 specification however limits whitespace characters only to:
- `u0009` (horizontal tab)
- `u000a` (line feed)
- `u000c` (form feed)
- `u000d` (carriage return)
- `u0020` (space)

Therefore I would propose to change the definition of whitespace in `/src/css/TokenStream.js` from `/\s/` to `/\u0009|\u000a|\u000c|\u000d|\u0020/`