### PR TITLE
Updated <gradient> regex to allow -webkit-gradient

### DIFF
--- a/src/css/ValidationTypes.js
+++ b/src/css/ValidationTypes.js
@@ -100,7 +100,7 @@ var ValidationTypes = {
         },        
         
         "<gradient>": function(part) {
-            return part.type == "function" && /^(?:\-(?:ms|moz|o|webkit)\-)?(?:repeating\-)?(?:radial|linear)\-gradient/i.test(part);
+            return part.type == "function" && /^(?:\-(?:ms|moz|o|webkit)\-)?(?:repeating\-)?(?:radial\-|linear\-)?gradient/i.test(part);
         },
         
         "<box>": function(part){

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -135,8 +135,8 @@
             "radial-gradient(top, #f2f2f2 0%, #cbcbcb 100%)",
             "repeating-linear-gradient(top, #f2f2f2 0%, #cbcbcb 100%)",
             "repeating-radial-gradient(top, #f2f2f2 0%, #cbcbcb 100%)",
-            "-ms-linear-gradient(top, #f2f2f2 0%, #cbcbcb 100%), url(foo.png)"
-            
+            "-ms-linear-gradient(top, #f2f2f2 0%, #cbcbcb 100%), url(foo.png)",
+            "-webkit-gradient(linear, left bottom, left top, from(#f2f2f2), to(#cbcbcb))"
         ],
         
         invalid: {


### PR DESCRIPTION
At the moment the parser doesn't allow -webkit-gradient() as a value for background-image 

This has been discussed in: https://github.com/stubbornella/csslint/issues/242

I've just made a small change to the regex used to match the gradient function allowing it to also match -webkit-gradient and updated the associated test to add a -webkit-gradient test case. 
