### PR TITLE
Add transparent to valid backround-color types

### DIFF
--- a/src/css/Properties.js
+++ b/src/css/Properties.js
@@ -79,7 +79,7 @@ var Properties = {
     "background"                    : 1,
     "background-attachment"         : { multi: "<attachment>", comma: true },
     "background-clip"               : { multi: "<box>", comma: true },
-    "background-color"              : "<color> | inherit",
+    "background-color"              : "<color> | transparent | inherit",
     "background-image"              : { multi: "<bg-image>", comma: true },
     "background-origin"             : { multi: "<box>", comma: true },
     "background-position"           : { multi: "<bg-position>", comma: true },


### PR DESCRIPTION
For https://github.com/stubbornella/csslint/issues/324

Edit: Retested and it didn't solve 324, but it still adds the valid background-color option
