### PR TITLE
Allow pixel ratios in media queries

### DIFF
--- a/src/css/Parser.js
+++ b/src/css/Parser.js
@@ -1333,7 +1333,7 @@ Parser.prototype = function(){
                 while(tokenStream.match([Tokens.PLUS, Tokens.MINUS, Tokens.DIMENSION,
                         Tokens.NUMBER, Tokens.STRING, Tokens.IDENT, Tokens.LENGTH,
                         Tokens.FREQ, Tokens.ANGLE, Tokens.TIME,
-                        Tokens.RESOLUTION])){
+                        Tokens.RESOLUTION, Tokens.SLASH])){
                     
                     value += tokenStream.token().value;
                     value += this._readWhitespace();                        

--- a/tests/css/Parser.js
+++ b/tests/css/Parser.js
@@ -955,6 +955,22 @@
             Assert.areEqual("orientation", result.features[1].name);
             Assert.areEqual("portrait", result.features[1].value);
             Assert.areEqual("only screen and (max-device-width:768px) and (orientation:portrait)", result.text);
+        },
+        
+        testComplexMediaQueryWithDevicePixelRatioAsFraction: function(){
+            var parser = new Parser();
+            var result = parser.parseMediaQuery("only screen and (-o-device-pixel-ratio: 3/2) and (-webkit-device-pixel-ratio: 1.5)");
+            
+            Assert.isInstanceOf(MediaQuery, result, "Result should be an instance of MediaQuery.");
+            Assert.areEqual(1, result.line, "Line should be 1");
+            Assert.areEqual(1, result.col, "Column should be 1");
+            Assert.areEqual("only", result.modifier);
+            Assert.areEqual("screen", result.mediaType);
+            Assert.areEqual(2, result.features.length, "Should be two features.");
+            Assert.areEqual("-o-device-pixel-ratio", result.features[0].name);
+            Assert.areEqual("3/2", result.features[0].value);
+            Assert.areEqual("-webkit-device-pixel-ratio", result.features[1].name);
+            Assert.areEqual("1.5", result.features[1].value);
         }
 
 
@@ -1115,7 +1131,7 @@
             Assert.areEqual(0, result.parts[0].green);
             Assert.areEqual(0, result.parts[0].blue);
         },
-		
+        
         testCSS2SystemColorValue: function(){
             var parser = new Parser();
             var result = parser.parsePropertyValue("InfoText");


### PR DESCRIPTION
Repackaging https://github.com/nzakas/parser-lib/pull/23 because of conflicts.
I've come across this issue in my sheets and @nzakas indicated that #23 had conflicts.
All code from @moddular
