### PR TITLE
CI tests on Node 0.6+ stable versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,8 @@
-script: "ant test"
+language: node_js
+node_js:
+  - "0.6"
+  - "0.8"
+  - "0.10"
+  - "0.11"
+script:
+  - ant test


### PR DESCRIPTION
Same as https://github.com/stubbornella/csslint/pull/379 without forcing the newer node engine version.
