### PR TITLE
support viewport relative units vh, vw and vm

### DIFF
--- a/src/css/PropertyValuePart.js
+++ b/src/css/PropertyValuePart.js
@@ -44,6 +44,9 @@ function PropertyValuePart(text, line, col){
             case "pt":
             case "pc":
             case "ch":
+            case "vh":
+            case "vw":
+            case "vm":
                 this.type = "length";
                 break;
                 

--- a/tests/css/Parser.js
+++ b/tests/css/Parser.js
@@ -1003,6 +1003,39 @@
             Assert.areEqual("ch", result.parts[0].units);
         },
 
+        testViewportRelativeHeightValue: function(){
+            var parser = new Parser();
+            var result = parser.parsePropertyValue("50vh");
+
+            Assert.isInstanceOf(parserlib.css.PropertyValue, result);
+            Assert.areEqual(1, result.parts.length);
+            Assert.areEqual("length", result.parts[0].type);
+            Assert.areEqual(50, result.parts[0].value);
+            Assert.areEqual("vh", result.parts[0].units);
+        },
+
+        testViewportRelativeWidthValue: function(){
+            var parser = new Parser();
+            var result = parser.parsePropertyValue("50vw");
+
+            Assert.isInstanceOf(parserlib.css.PropertyValue, result);
+            Assert.areEqual(1, result.parts.length);
+            Assert.areEqual("length", result.parts[0].type);
+            Assert.areEqual(50, result.parts[0].value);
+            Assert.areEqual("vw", result.parts[0].units);
+        },
+
+        testViewportRelativeMinValue: function(){
+            var parser = new Parser();
+            var result = parser.parsePropertyValue("50vm");
+
+            Assert.isInstanceOf(parserlib.css.PropertyValue, result);
+            Assert.areEqual(1, result.parts.length);
+            Assert.areEqual("length", result.parts[0].type);
+            Assert.areEqual(50, result.parts[0].value);
+            Assert.areEqual("vm", result.parts[0].units);
+        },
+
         testPercentageValue: function(){
             var parser = new Parser();
             var result = parser.parsePropertyValue("25.4%");


### PR DESCRIPTION
needed for csslint to support stuff like

```
height:50vh;
```
