### PR TITLE
Add @-ms-viewport for IE10

### DIFF
--- a/src/css/Tokens.js
+++ b/src/css/Tokens.js
@@ -31,7 +31,7 @@ var Tokens  = [
     { name: "FONT_FACE_SYM", text: "@font-face"},
     { name: "CHARSET_SYM", text: "@charset"},
     { name: "NAMESPACE_SYM", text: "@namespace"},
-    { name: "VIEWPORT_SYM", text: "@viewport"},
+    { name: "VIEWPORT_SYM", text: ["@viewport", "@-ms-viewport"]},
     { name: "UNKNOWN_SYM" },
     //{ name: "ATKEYWORD"},
 

--- a/tests/css/Parser.js
+++ b/tests/css/Parser.js
@@ -1517,6 +1517,24 @@
             Assert.isTrue(true);  //just don't want an error
         },
 
+        testMSViewport: function(){
+            var parser = new Parser({ strict: true});
+            var result = parser.parse("@-ms-viewport { width: 397px; }");
+            Assert.isTrue(true);
+        },
+
+        testMSViewportInsideDeviceWidth: function(){
+            var parser = new Parser({ strict: true});
+            var result = parser.parse("@-ms-viewport { width: device-width; }");
+            Assert.isTrue(true);
+        },
+
+        testMSViewportInsideDeviceHeight: function(){
+            var parser = new Parser({ strict: true});
+            var result = parser.parse("@-ms-viewport { width: device-height; }");
+            Assert.isTrue(true);
+        },
+
         testViewportEventFires: function(){
             var parser = new Parser({ strict:true}),
                 calledStart = false,


### PR DESCRIPTION
Test cases taken from the documentation in
http://msdn.microsoft.com/en-us/library/ie/hh869615%28v=vs.85%29.aspx
Fixes https://github.com/stubbornella/csslint/issues/401

---

This currently fails for the case of a viewport nested in a media query http://dev.w3.org/csswg/css-device-adapt/#media-queries
I'm throwing this up so maybe someone (ping @jklein) can figure out a good solution.
