### PR TITLE
Update support and tests for unicode-bidi

### DIFF
--- a/src/css/Properties.js
+++ b/src/css/Properties.js
@@ -491,7 +491,7 @@ var Properties = {
     "transition-timing-function"    : 1,
 
     //U
-    "unicode-bidi"                  : "normal | embed | bidi-override | inherit",
+    "unicode-bidi"                  : "normal | embed | isolate | bidi-override | isolate-override | plaintext | inherit",
     "user-modify"                   : "read-only | read-write | write-only | inherit",
     "user-select"                   : "none | text | toggle | element | elements | all | inherit",
 

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -755,6 +755,24 @@
         }
     }));
 
+    suite.add(new ValidationTestCase({
+        property: "unicode-bidi",
+
+        valid: [
+            "normal",
+            "embed",
+            "isolate",
+            "bidi-override",
+            "isolate-override",
+            "plaintext",
+            "inherit"
+        ],
+
+        invalid: {
+            "foo" : "Expected (normal | embed | isolate | bidi-override | isolate-override | plaintext | inherit) but found 'foo'."
+        }
+    }));
+
     YUITest.TestRunner.add(suite);
 
 })();


### PR DESCRIPTION
Adds support for the values `isolate`, `isolate-override`, and `plaintext` for property `unicode-bidi`.
Adds tests for `unicode-bidi`.

This should resolve #95.
