### PR TITLE
Add touch-action and -ms-touch-action.

### DIFF
--- a/src/css/Properties.js
+++ b/src/css/Properties.js
@@ -481,6 +481,8 @@ var Properties = {
     "text-transform"                : "capitalize | uppercase | lowercase | none | inherit",
     "text-wrap"                     : "normal | none | avoid",
     "top"                           : "<margin-width> | inherit",
+    "-ms-touch-action"              : "auto | none | pan-x | pan-y",
+    "touch-action"                  : "auto | none | pan-x | pan-y",
     "transform"                     : 1,
     "transform-origin"              : 1,
     "transform-style"               : 1,

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -675,6 +675,36 @@
     }));
 
     suite.add(new ValidationTestCase({
+        property: "-ms-touch-action",
+
+        valid: [
+            "auto",
+            "none",
+            "pan-x",
+            "pan-y"
+        ],
+
+        invalid: {
+            "foo" : "Expected (auto | none | pan-x | pan-y) but found 'foo'."
+        }
+    }));
+
+    suite.add(new ValidationTestCase({
+        property: "touch-action",
+
+        valid: [
+            "auto",
+            "none",
+            "pan-x",
+            "pan-y"
+        ],
+
+        invalid: {
+            "foo" : "Expected (auto | none | pan-x | pan-y) but found 'foo'."
+        }
+    }));
+
+    suite.add(new ValidationTestCase({
         property: "z-index",
 
         valid: [


### PR DESCRIPTION
`touch-action` is a [specced property](https://dvcs.w3.org/hg/pointerevents/raw-file/tip/pointerEvents.html#the-touch-action-css-property); this adds it to the list.

It was implemented in IE10 as `-ms-touch-action` and unprefixed in IE11.
