### PR TITLE
Allow underscores in identifiers

### DIFF
--- a/src/css/PropertyValuePart.js
+++ b/src/css/PropertyValuePart.js
@@ -149,7 +149,7 @@ function PropertyValuePart(text, line, col){
     } else if (/^[\,\/]$/.test(text)){
         this.type   = "operator";
         this.value  = text;
-    } else if (/^[a-z\-\u0080-\uFFFF][a-z0-9\-\u0080-\uFFFF]*$/i.test(text)){
+    } else if (/^[a-z\-_\u0080-\uFFFF][a-z0-9\-_\u0080-\uFFFF]*$/i.test(text)){
         this.type   = "identifier";
         this.value  = text;
     }

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -69,7 +69,8 @@
             "foo",
             "foo, bar",
             "none, none",
-            "none, foo"
+            "none, foo",
+            "has_underscore"
         ],
 
         invalid: {


### PR DESCRIPTION
From what I can tell reading about [CSS3 syntax](http://www.w3.org/TR/css3-syntax/#typedef-ident-token) (please verify), underscores are valid in identifiers.

Resolves #99 / https://github.com/stubbornella/csslint/issues/450.
