### PR TITLE
Add Opera viewport token

### DIFF
--- a/src/css/Tokens.js
+++ b/src/css/Tokens.js
@@ -31,7 +31,7 @@ var Tokens  = [
     { name: "FONT_FACE_SYM", text: "@font-face"},
     { name: "CHARSET_SYM", text: "@charset"},
     { name: "NAMESPACE_SYM", text: "@namespace"},
-    { name: "VIEWPORT_SYM", text: ["@viewport", "@-ms-viewport"]},
+    { name: "VIEWPORT_SYM", text: ["@viewport", "@-ms-viewport", "@-o-viewport"]},
     { name: "UNKNOWN_SYM" },
     //{ name: "ATKEYWORD"},
 


### PR DESCRIPTION
Seeing 

```
Unknown @ rule: @-o-viewport. This rule looks for recoverable syntax errors. (errors)
```

when parsing some CSS.
