### PR TITLE
[Fix #133] StringReader fails to normalize Windows line endings

### DIFF
--- a/src/util/StringReader.js
+++ b/src/util/StringReader.js
@@ -13,7 +13,7 @@ function StringReader(text){
      * @type String
      * @private
      */
-    this._input = text.replace(/\n\r?/g, "\n");
+    this._input = text.replace(/(\r|\n){1,2}/g, "\n");
 
 
     /**


### PR DESCRIPTION
[Fix #133] StringReader fails to normalize Windows line endings

`\r` matches a carriage return

`\n` matches a newline character.

`{1, 2}` matches between either 1 or 2 of the preceding tokens

This way you can start with either and should cover both linux or windows to fix #133

cc: @nschonni

<!---
@huboard:{"order":145.0,"milestone_order":145,"custom_state":""}
-->
