### PR TITLE
Fixes for @document blocks

### DIFF
--- a/src/css/Parser.js
+++ b/src/css/Parser.js
@@ -1988,6 +1988,7 @@ Parser.prototype = function(){
 
                 this._readWhitespace();
                 tokenStream.mustMatch(Tokens.RBRACE);
+                this._readWhitespace();
 
             },
 

--- a/src/css/Parser.js
+++ b/src/css/Parser.js
@@ -795,17 +795,16 @@ Parser.prototype = function(){
                     col:       token.startCol
                 });
 
-                while(true) {
-                    if (tokenStream.peek() === Tokens.PAGE_SYM){
-                        this._page();
-                    } else if (tokenStream.peek() === Tokens.FONT_FACE_SYM){
-                        this._font_face();
-                    } else if (tokenStream.peek() === Tokens.VIEWPORT_SYM){
-                        this._viewport();
-                    } else if (tokenStream.peek() === Tokens.MEDIA_SYM){
-                        this._media();
-                    } else if (!this._ruleset()){
-                        break;
+                var ok = true;
+                while (ok) {
+                    switch (tokenStream.peek()) {
+                        case Tokens.PAGE_SYM:       this._page(); break;
+                        case Tokens.FONT_FACE_SYM:  this._font_face(); break;
+                        case Tokens.VIEWPORT_SYM:   this._viewport(); break;
+                        case Tokens.MEDIA_SYM:      this._media(); break;
+                        case Tokens.KEYFRAMES_SYM:  this._keyframes(); break;
+                        case Tokens.DOCUMENT_SYM:   this._document(); break;
+                        default:                    ok = !!this._ruleset();
                     }
                 }
 

--- a/src/css/Parser.js
+++ b/src/css/Parser.js
@@ -810,6 +810,7 @@ Parser.prototype = function(){
                 }
 
                 tokenStream.mustMatch(Tokens.RBRACE);
+                token = tokenStream.token();
                 this._readWhitespace();
 
                 this.fire({

--- a/tests/css/CSSParserTests.htm
+++ b/tests/css/CSSParserTests.htm
@@ -1645,7 +1645,7 @@ YAHOO.test.CSSParser = (function(){
 
             parser.addListener("enddocument", function(event) {
                 assert.areEqual(1, event.line, "Line should be 1");
-                assert.areEqual(1, event.col, "Column should be 1");
+                assert.areEqual(25, event.col, "Column should be 25");
                 calledEnd = true;
             });
 

--- a/tests/css/CSSParserTests.htm
+++ b/tests/css/CSSParserTests.htm
@@ -1632,6 +1632,18 @@ YAHOO.test.CSSParser = (function(){
             assert.isTrue(valid);
         },
 
+        testDocumentWithKeyframes: function(){
+            var parser = new Parser({ strict: true}),
+                valid = true;
+
+            parser.addListener("error", function(event) {
+                valid = false;
+            });
+
+            var result = parser.parse("@document url-prefix() { @keyframes 'diagonal-slide' {  from { left: 0; top: 0; } to { left: 100px; top: 100px; } } }");
+            assert.isTrue(valid);
+        },
+
         testDocumentEventFires: function(){
             var parser = new Parser({ strict:true}),
                 calledStart = false,

--- a/tests/css/Parser.js
+++ b/tests/css/Parser.js
@@ -1821,7 +1821,7 @@
 
             parser.addListener("enddocument", function(event) {
                 Assert.areEqual(1, event.line, "Line should be 1");
-                Assert.areEqual(1, event.col, "Column should be 1");
+                Assert.areEqual(25, event.col, "Column should be 25");
                 calledEnd = true;
             });
 

--- a/tests/css/Parser.js
+++ b/tests/css/Parser.js
@@ -1808,6 +1808,18 @@
             Assert.isTrue(valid);
         },
 
+        testDocumentWithKeyframes: function(){
+            var parser = new Parser({ strict: true}),
+                valid = true;
+
+            parser.addListener("error", function(event) {
+                valid = false;
+            });
+
+            var result = parser.parse("@document url-prefix() { @keyframes 'diagonal-slide' {  from { left: 0; top: 0; } to { left: 100px; top: 100px; } } }");
+            Assert.isTrue(valid);
+        },
+
         testDocumentEventFires: function(){
             var parser = new Parser({ strict:true}),
                 calledStart = false,


### PR DESCRIPTION
* Fix `line`, `col` in `"enddocument"` event.
* Support `@keyframes` inside `@document` blocks.
* Support nested `@document` blocks: `@document` inside `@document`.
* Fix `@keyframes`: consume trailing whitespace after `RBRACE`<br>All other block parsers do it, but `_keyframes()` didn't, consequently breaking the parser after `@keyframes` inside `@document` blocks.