### PR TITLE
A padding value can't be negative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ Desktop.ini
 
 # NPM files
 npm-debug.log
+
+# IntelliJ project info
+.idea
+
+# original release
+.release-original

--- a/src/css/ValidationTypes.js
+++ b/src/css/ValidationTypes.js
@@ -177,7 +177,7 @@ var ValidationTypes = {
         },
 
         "<padding-width>": function(part){
-            return this["<length>"](part) || this["<percentage>"](part);
+            return part.value >= 0 && (this["<length>"](part) || this["<percentage>"](part));
         },
 
         "<shape>": function(part){


### PR DESCRIPTION
In different sources you will find that padding values may not be negative (http://www.w3.org/TR/CSS21/box.html#padding-properties, http://www.w3.org/wiki/CSS/Properties/padding), yet parser-lib does not reject it.
I could work parser-lib like-wise.

Nevermind the .gitignore commit