### PR TITLE
Clip properties

### DIFF
--- a/src/css/Properties.js
+++ b/src/css/Properties.js
@@ -247,6 +247,7 @@ var Properties = {
     "caption-side"                  : "top | bottom | inherit",
     "clear"                         : "none | right | left | both | inherit",
 	"clip"							: "<shape> | auto | inherit",
+	"-webkit-clip-path"				: "<uri> | <clip-path> | none",
 	"clip-path"						: "<uri> | <clip-path> | none", // "<clip-source> | [ <basic-shape> || <geometry-box> ] | none",
 	"clip-rule"						: "nonzero | evenodd | inherit",
     "color"                         : "<color> | inherit",

--- a/src/css/Properties.js
+++ b/src/css/Properties.js
@@ -246,7 +246,9 @@ var Properties = {
     //C
     "caption-side"                  : "top | bottom | inherit",
     "clear"                         : "none | right | left | both | inherit",
-    "clip"                          : 1,
+	"clip"							: "<shape> | auto | inherit",
+	"clip-path"						: "<uri> | <clip-path> | none", // "<clip-source> | [ <basic-shape> || <geometry-box> ] | none",
+	"clip-rule"						: "nonzero | evenodd | inherit",
     "color"                         : "<color> | inherit",
     "color-profile"                 : 1,
     "column-count"                  : "<integer> | auto",                      //http://www.w3.org/TR/css3-multicol/

--- a/src/css/Properties.js
+++ b/src/css/Properties.js
@@ -246,10 +246,10 @@ var Properties = {
     //C
     "caption-side"                  : "top | bottom | inherit",
     "clear"                         : "none | right | left | both | inherit",
-	"clip"							: "<shape> | auto | inherit",
-	"-webkit-clip-path"				: "<uri> | <clip-path> | none",
-	"clip-path"						: "<uri> | <clip-path> | none", // "<clip-source> | [ <basic-shape> || <geometry-box> ] | none",
-	"clip-rule"						: "nonzero | evenodd | inherit",
+    "clip"                          : "<shape> | auto | inherit",
+    "-webkit-clip-path"             : "<uri> | <clip-path> | none",
+    "clip-path"                     : "<uri> | <clip-path> | none", // "<clip-source> | [ <basic-shape> || <geometry-box> ] | none",
+    "clip-rule"                     : "nonzero | evenodd | inherit",
     "color"                         : "<color> | inherit",
     "color-profile"                 : 1,
     "column-count"                  : "<integer> | auto",                      //http://www.w3.org/TR/css3-multicol/

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -599,9 +599,7 @@
 
         invalid: {
 	        "stroke-box ellipse(40% 40%) 40%" : "Expected end of value but found '40%'.",
-	        "x-box" : "Expected <geometry-box> but found 'x-box'.",
             "foo" : "Expected (<uri> | <clip-path> | none) but found 'foo'.",
-	        "invert(40% 40%)" : "Expected (<uri> | <clip-path> | none) but found 'invert(40% 40%)'",
 	        "40%" : "Expected (<uri> | <clip-path> | none) but found '40%'.",
 	        "0.4" : "Expected (<uri> | <clip-path> | none) but found '0.4'."
         }

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -599,7 +599,9 @@
 
         invalid: {
 	        "stroke-box ellipse(40% 40%) 40%" : "Expected end of value but found '40%'.",
+	        "x-box" : "Expected (<uri> | <clip-path> | none) but found 'x-box'.",
             "foo" : "Expected (<uri> | <clip-path> | none) but found 'foo'.",
+	        "invert(40% 40%)" : "Expected (<uri> | <clip-path> | none) but found 'invert(40% 40%)'.",
 	        "40%" : "Expected (<uri> | <clip-path> | none) but found '40%'.",
 	        "0.4" : "Expected (<uri> | <clip-path> | none) but found '0.4'."
         }

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -587,7 +587,7 @@
         property: "clip-path",
 
         valid: [
-            "rect(10% 15% 10% 15%)",
+            "inset(10% 15% 10% 15%)",
             "circle(30% at 85% 15%)",
 	        "url('#myPath')",
 	        "ellipse(40% 40%)",
@@ -598,10 +598,10 @@
         ],
 
         invalid: {
-	        "stroke-box ellipse(40% 40%) 40%" : "Expected 2 values at most",
+	        "stroke-box ellipse(40% 40%) 40%" : "Expected end of value but found '40%'.",
 	        "x-box" : "Expected <geometry-box> but found 'x-box'.",
             "foo" : "Expected (<uri> | <clip-path> | none) but found 'foo'.",
-	        "invert(40% 40%)" : "Expected <basic-shape> but found 'invert(40% 40%)'.",
+	        "invert(40% 40%)" : "Expected (<uri> | <clip-path> | none) but found 'invert(40% 40%)'",
 	        "40%" : "Expected (<uri> | <clip-path> | none) but found '40%'.",
 	        "0.4" : "Expected (<uri> | <clip-path> | none) but found '0.4'."
         }

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -579,7 +579,7 @@
         ],
 
         invalid: {
-            "foo" : "Expected (<shape> | inherit) but found 'foo'.",
+            "foo" : "Expected (<shape> | auto | inherit) but found 'foo'."
         }
     }));
 
@@ -601,7 +601,7 @@
 	        "stroke-box ellipse(40% 40%) 40%" : "Expected 2 values at most",
 	        "x-box" : "Expected <geometry-box> but found 'x-box'.",
             "foo" : "Expected (<uri> | <clip-path> | none) but found 'foo'.",
-	        "invert(40% 40%)" : "Expected <basic-shape> but found 'x-box'.",
+	        "invert(40% 40%)" : "Expected <basic-shape> but found 'invert(40% 40%)'.",
 	        "40%" : "Expected (<uri> | <clip-path> | none) but found '40%'.",
 	        "0.4" : "Expected (<uri> | <clip-path> | none) but found '0.4'."
         }
@@ -617,7 +617,7 @@
         ],
 
         invalid: {
-            "foo" : "Expected (nonzero | evenodd | inherit) but found 'foo'.",
+            "foo" : "Expected (nonzero | evenodd | inherit) but found 'foo'."
         }
     }));
 

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -571,6 +571,57 @@
     }));
 
     suite.add(new ValidationTestCase({
+        property: "clip",
+
+        valid: [
+            "rect(10%, 85%, 90%, 15%)",
+            'auto'
+        ],
+
+        invalid: {
+            "foo" : "Expected (<shape> | inherit) but found 'foo'.",
+        }
+    }));
+
+    suite.add(new ValidationTestCase({
+        property: "clip-path",
+
+        valid: [
+            "rect(10% 15% 10% 15%)",
+            "circle(30% at 85% 15%)",
+	        "url('#myPath')",
+	        "ellipse(40% 40%)",
+	        "margin-box",
+	        "ellipse(40% 40%) content-box",
+	        "stroke-box ellipse(40% 40%)",
+	        "none"
+        ],
+
+        invalid: {
+	        "stroke-box ellipse(40% 40%) 40%" : "Expected 2 values at most",
+	        "x-box" : "Expected <geometry-box> but found 'x-box'.",
+            "foo" : "Expected (<uri> | <clip-path> | none) but found 'foo'.",
+	        "invert(40% 40%)" : "Expected <basic-shape> but found 'x-box'.",
+	        "40%" : "Expected (<uri> | <clip-path> | none) but found '40%'.",
+	        "0.4" : "Expected (<uri> | <clip-path> | none) but found '0.4'."
+        }
+    }));
+
+    suite.add(new ValidationTestCase({
+        property: "clip-rule",
+
+        valid: [
+            "nonzero",
+            "evenodd",
+            "inherit"
+        ],
+
+        invalid: {
+            "foo" : "Expected (nonzero | evenodd | inherit) but found 'foo'.",
+        }
+    }));
+
+    suite.add(new ValidationTestCase({
         property: "color",
 
         valid: [


### PR DESCRIPTION
The clip property has has browser support for a long time, and even parser-lib was nearly there. The clip property is now deprecated, and its successor clip-path is more versatile, the use cases are much more credible. Also support for the clip-rule propery. The properties can be used without support of a svg file.