### PR TITLE
Add support for empty file.

### DIFF
--- a/src/util/TokenStreamBase.js
+++ b/src/util/TokenStreamBase.js
@@ -16,7 +16,7 @@ function TokenStreamBase(input, tokenData){
      * @property _reader
      * @private
      */
-    this._reader = input ? new StringReader(input.toString()) : null;
+    this._reader = input !== undefined ? new StringReader(input.toString()) : null;
 
     /**
      * Token object for the last consumed token.

--- a/tests/css/TokenStream.js
+++ b/tests/css/TokenStream.js
@@ -53,6 +53,14 @@
     var suite = new YUITest.TestSuite("CSS Tokens");
 
 
+    suite.add(new CSSTokenTestCase({
+        name : "Tests for empty",
+
+        patterns: {
+            "": [CSSTokens.EOF],
+        }
+    }));
+
     //note: \r\n is normalized to just \n by StringReader
     suite.add(new CSSTokenTestCase({
         name : "Tests for Whitespace",


### PR DESCRIPTION
When a file is empty, _CSSLint_ returns an error : 
> Fatal error, cannot continue: Cannot read property 'getLine' of null