### PR TITLE
Don't return fatal error if CSS file is empty.

### DIFF
--- a/src/util/TokenStreamBase.js
+++ b/src/util/TokenStreamBase.js
@@ -16,7 +16,7 @@ function TokenStreamBase(input, tokenData){
      * @property _reader
      * @private
      */
-    this._reader = input ? new StringReader(input.toString()) : null;
+    this._reader = new StringReader(input ? input.toString() : '');
 
     /**
      * Token object for the last consumed token.

--- a/tests/css/TokenStream.js
+++ b/tests/css/TokenStream.js
@@ -55,6 +55,14 @@
 
     //note: \r\n is normalized to just \n by StringReader
     suite.add(new CSSTokenTestCase({
+        name : "Tests for empty input",
+
+        patterns: {
+            ""        : [CSSTokens.EOF]
+        }
+    }));
+
+    suite.add(new CSSTokenTestCase({
         name : "Tests for Whitespace",
 
         patterns: {


### PR DESCRIPTION
This is a variant on PR #183 which also adds a test case.