### PR TITLE
Fix line numbers when the input contains multiple sequential \n characters.

### DIFF
--- a/src/util/StringReader.js
+++ b/src/util/StringReader.js
@@ -13,7 +13,7 @@ function StringReader(text){
      * @type String
      * @private
      */
-    this._input = text.replace(/(\r|\n){1,2}/g, "\n");
+    this._input = text.replace(/(\r\n?|\n)/g, "\n");
 
 
     /**


### PR DESCRIPTION
For example, the input `\r\n\n\r` should represent three new lines. But:
```
> text = '\r\n\n\r'
> text.replace(/(\r|\n){1,2}/g, "\n");  // previous code says this is only two newlines
'\n\n'
> text.replace(/(\r\n?|\n)/g, "\n"); // this patch returns three, as expected.
'\n\n\n'
```

This PR fixes issue #155.