### PR TITLE
Allow calculated values for padding.

### DIFF
--- a/src/css/ValidationTypes.js
+++ b/src/css/ValidationTypes.js
@@ -181,7 +181,8 @@ var ValidationTypes = {
         },
 
         "<padding-width>": function(part){
-            return part.value >= 0 && (this["<length>"](part) || this["<percentage>"](part));
+            return (this["<length>"](part) || this["<percentage>"](part)) &&
+                (String(part) === "0" || part.type === "function" || (part.value) >= 0);
         },
 
         "<shape>": function(part){

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -1202,8 +1202,11 @@
         property: "padding-left",
 
         valid: [
+            "0",
             "6px",
             "3%",
+            "1em",
+            "calc(100% - 80px)",
             "inherit"
         ],
 


### PR DESCRIPTION
This is a follow up to 17a2f0190e0670be1c1a2d9a8272080c5c7e5061, which began to enforce the non-negative value restriction on `<padding-width>` but neglected to account for the `calc()` function.