### PR TITLE
Allow matching functions as literals.

### DIFF
--- a/src/css/ValidationTypes.js
+++ b/src/css/ValidationTypes.js
@@ -8,7 +8,10 @@ var ValidationTypes = {
             i, len, found = false;
 
         for (i=0,len=args.length; i < len && !found; i++){
-            if (text === args[i].toLowerCase()){
+            if (args[i].slice(-2) === "()"){
+                found = (part.type === "function" &&
+                         part.name === args[i].slice(0, -2));
+            } else if (text === args[i].toLowerCase()){
                 found = true;
             }
         }
@@ -92,7 +95,7 @@ var ValidationTypes = {
         },
 
         "<attr>": function(part){
-            return part.type === "function" && part.name === "attr";
+            return ValidationTypes.isLiteral(part, "attr()");
         },
 
         "<bg-image>": function(part){
@@ -108,7 +111,7 @@ var ValidationTypes = {
         },
 
         "<content>": function(part){
-            return part.type === "function" && part.name === "content";
+            return ValidationTypes.isLiteral(part, "content()");
         },
 
         "<relative-size>": function(part){
@@ -186,7 +189,7 @@ var ValidationTypes = {
         },
 
         "<shape>": function(part){
-            return part.type === "function" && (part.name === "rect" || part.name === "inset-rect");
+            return ValidationTypes.isLiteral(part, "rect() | inset-rect()");
         },
 
         "<basic-shape>": function(part){
@@ -194,9 +197,7 @@ var ValidationTypes = {
             // circle() = circle( [<shape-radius>]? [at <position>]? )
             // ellipse() = ellipse( [<shape-radius>{2}]? [at <position>]? )
             // polygon() = polygon( [<fill-rule>,]? [<shape-arg> <shape-arg>]# )
-            return part.type === "function" && (
-                part.name === "inset" || part.name === "circle" || part.name === "ellipse" || part.name === "polygon"
-            );
+            return ValidationTypes.isLiteral(part, "inset() | circle() | ellipse() | polygon()");
         },
 
         "<shape-box>": function(part) {
@@ -240,18 +241,11 @@ var ValidationTypes = {
         },
 
         "<filter-function>": function(part){
-            return part.type === "function" && (
-                    part.name === 'blur' ||
-                    part.name === 'brightness' ||
-                    part.name === 'contrast' ||
-                    part.name === 'custom' || // Not actually in formal spec.
-                    part.name === 'drop-shadow' ||
-                    part.name === 'grayscale' ||
-                    part.name === 'hue-rotate' ||
-                    part.name === 'invert' ||
-                    part.name === 'opacity' ||
-                    part.name === 'saturate' ||
-                    part.name === 'sepia');
+            // custom() isn't actually in the spec
+            return ValidationTypes.isLiteral(
+                part, "blur() | brightness() | contrast() | custom() | " +
+                    "drop-shadow() | grayscale() | hue-rotate() | invert() | " +
+                    "opacity() | saturate() | sepia()");
         }
     },
 


### PR DESCRIPTION
I've updated several simple `ValidationType` functions to show how this can be used to simplify common matchers.  It will also be used in a follow-up patch to validate the `font-variant-alternates` property which involves a large number of CSS function options.