### PR TITLE
Fix the Reader#readWhile implementation.

### DIFF
--- a/src/util/StringReader.js
+++ b/src/util/StringReader.js
@@ -204,11 +204,11 @@ StringReader.prototype = {
     readWhile: function(filter){
 
         var buffer = "",
-            c = this.read();
+            c = this.peek();
 
         while(c !== null && filter(c)){
-            buffer += c;
-            c = this.read();
+            buffer += this.read();
+            c = this.peek();
         }
 
         return buffer;

--- a/tests/util/StringReader.js
+++ b/tests/util/StringReader.js
@@ -172,6 +172,23 @@
             Assert.areEqual(testString, result);
             Assert.areEqual(1, reader.getLine());
             Assert.areEqual(13, reader.getCol());
+        },
+
+        /*
+         * Tests that the filter function works.
+         */
+        testReadWhileFilter: function(){
+            var testString = "Hello world!",
+                reader = new StringReader(testString);
+
+            var result = reader.readWhile(function(c){
+                return c !== ' ';
+            });
+
+            Assert.areEqual('Hello', result);
+            Assert.areEqual(reader.peek(), ' ');
+            Assert.areEqual(1, reader.getLine());
+            Assert.areEqual(6, reader.getCol());
         }
     }));
 


### PR DESCRIPTION
Previously it would read an extra character after the filter returned false.  Luckily, this function does not appear to be used (yet) anywhere else in the parser, but seems like a good idea to fix it regardless.