### PR TITLE
Throw SyntaxError if pseudo selector is invalid

### DIFF
--- a/src/css/Parser.js
+++ b/src/css/Parser.js
@@ -1575,6 +1575,10 @@ Parser.prototype = function(){
 
                     if (pseudo){
                         pseudo = new SelectorSubPart(colons + pseudo, "pseudo", line, col);
+                    }else{
+                        var startLine = tokenStream.LT(1).startLine,
+                            startCol  = tokenStream.LT(0).startCol;
+                        throw new SyntaxError("Expected a `FUNCTION` or `IDENT` after colon at line " + startLine + ", col " + startCol + ".", startLine, startCol);
                     }
                 }
 

--- a/tests/css/Parser.js
+++ b/tests/css/Parser.js
@@ -444,6 +444,17 @@ var YUITest = require("yuitest"),
 
         name: "Pseudo Class Selector Tests",
 
+        _should: {
+            error: {
+                testInvalidPseudoClassSelector: "Expected a `FUNCTION` or `IDENT` after colon at line 1, col 2."
+            }
+        },
+
+        testInvalidPseudoClassSelector: function(){
+            var parser = new Parser();
+            parser.parseSelector("a:");
+        },
+
         testSimplePseudoClassSelector: function(){
             var parser = new Parser();
             var result = parser.parseSelector("a:hover");


### PR DESCRIPTION
i.e. a COLON is not followed by a FUNCTION or IDENT token. e.g. `a:`. 

Fixes CSSLint/csslint#639