### PR TITLE
Add `space` value for `border-image-repeat`

### DIFF
--- a/src/css/Properties.js
+++ b/src/css/Properties.js
@@ -93,7 +93,7 @@ var Properties = module.exports = {
     "border-color"                      : "<color>{1,4}",
     "border-image"                      : 1,
     "border-image-outset"               : "[ <length> | <number> ]{1,4}",
-    "border-image-repeat"               : "[ stretch | repeat | round ]{1,2}",
+    "border-image-repeat"               : "[ stretch | repeat | round | space ]{1,2}",
     "border-image-slice"                : "<border-image-slice>",
     "border-image-source"               : "<image> | none",
     "border-image-width"                : "[ <length> | <percentage> | <number> | auto ]{1,4}",

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -503,6 +503,20 @@ var YUITest = require("yuitest"),
     }));
 
     suite.add(new ValidationTestCase({
+        property: "border-image-repeat",
+
+        valid: [
+            "stretch",
+            "round stretch"
+        ],
+
+        invalid: {
+            "foo": "Expected ([ stretch | repeat | round | space ]{1,2}) but found 'foo'.",
+            "round stretch foo": "Expected end of value but found 'foo'."
+        }
+    }));
+
+    suite.add(new ValidationTestCase({
         property: "border-image-slice",
 
         valid: [

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -507,6 +507,9 @@ var YUITest = require("yuitest"),
 
         valid: [
             "stretch",
+            "repeat",
+            "round",
+            "space",
             "round stretch"
         ],
 


### PR DESCRIPTION
When I was try to find bug for issue CSSLint/csslint#718, I notice that not all valid properties for `border-image-repeat` are described. So I added `space`. Also I added tests for `border-image-repeat`.

They all passed:

```shell
✔ 'initial' is a valid value for 'border-image-repeat'
✔ 'inherit' is a valid value for 'border-image-repeat'
✔ 'unset' is a valid value for 'border-image-repeat'
✔ 'stretch' is a valid value for 'border-image-repeat'
✔ 'round stretch' is a valid value for 'border-image-repeat'
✔ 'foo' is an invalid value for 'border-image-repeat'
✔ 'round stretch foo' is an invalid value for 'border-image-repeat'
```

So parser-lib is not under suspicion =)