### PR TITLE
Fix colors to fit current CSS Color Module Level 3

### DIFF
--- a/src/css/Colors.js
+++ b/src/css/Colors.js
@@ -164,6 +164,7 @@ var Colors = module.exports = {
     buttontext              : "Text on push buttons.",
     captiontext             : "Text in caption, size box, and scrollbar arrow box.",
     graytext                : "Grayed (disabled) text. This color is set to #000 if the current display driver does not support a solid gray color.",
+    greytext                : "Greyed (disabled) text. This color is set to #000 if the current display driver does not support a solid grey color.",
     highlight               : "Item(s) selected in a control.",
     highlighttext           : "Text of item(s) selected in a control.",
     inactiveborder          : "Inactive window border.",

--- a/src/css/Colors.js
+++ b/src/css/Colors.js
@@ -94,7 +94,7 @@ var Colors = module.exports = {
     mediumaquamarine        : "#66cdaa",
     mediumblue              : "#0000cd",
     mediumorchid            : "#ba55d3",
-    mediumpurple            : "#9370d8",
+    mediumpurple            : "#9370db",
     mediumseagreen          : "#3cb371",
     mediumslateblue         : "#7b68ee",
     mediumspringgreen       : "#00fa9a",
@@ -115,7 +115,7 @@ var Colors = module.exports = {
     palegoldenrod           : "#eee8aa",
     palegreen               : "#98fb98",
     paleturquoise           : "#afeeee",
-    palevioletred           : "#d87093",
+    palevioletred           : "#db7093",
     papayawhip              : "#ffefd5",
     peachpuff               : "#ffdab9",
     peru                    : "#cd853f",
@@ -153,8 +153,8 @@ var Colors = module.exports = {
     yellowgreen             : "#9acd32",
     // 'currentColor' color keyword https: //www.w3.org/TR/css3-color/#currentcolor
     currentColor            : "The value of the 'color' property.",
-    // CSS2 system colors https: //www.w3.org/TR/css3-color/#css2-system
-    activeBorder            : "Active window border.",
+    // CSS2 system colors https://www.w3.org/TR/css3-color/#css2-system
+    activeborder            : "Active window border.",
     activecaption           : "Active window caption.",
     appworkspace            : "Background color of multiple document interface.",
     background              : "Desktop background.",
@@ -164,7 +164,6 @@ var Colors = module.exports = {
     buttontext              : "Text on push buttons.",
     captiontext             : "Text in caption, size box, and scrollbar arrow box.",
     graytext                : "Grayed (disabled) text. This color is set to #000 if the current display driver does not support a solid gray color.",
-    greytext                : "Greyed (disabled) text. This color is set to #000 if the current display driver does not support a solid grey color.",
     highlight               : "Item(s) selected in a control.",
     highlighttext           : "Text of item(s) selected in a control.",
     inactiveborder          : "Inactive window border.",


### PR DESCRIPTION
While I was checking issue CSSLint/csslint#717, I've noticed some mistakes in this module and fix it to fit [CSS Color Module Level 3](https://www.w3.org/TR/css3-color/#svg-color) [Recommendation]