### PR TITLE
Add minimal support of CSS custom properties

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,6 +2,7 @@
   "bitwise":    true,
   "curly":      true,
   "eqeqeq":     true,
+  "eqnull":     true,
   "evil":       true,
   "forin":      true,
   "freeze":     true,

--- a/src/util/StringReader.js
+++ b/src/util/StringReader.js
@@ -165,6 +165,18 @@ StringReader.prototype = {
     //-------------------------------------------------------------------------
 
     /**
+     * Reads a given number of characters without advancing the cursor.
+     * @param {int} count How many characters to look ahead (default is 1).
+     * @return {String} The characters as a string, or an empty string if
+     *     there is no next character.
+     * @method peek
+     */
+    peekCount: function(count) {
+        count = typeof count === "undefined" ? 1 : Math.max(count, 0);
+        return this._input.substring(this._cursor, this._cursor + count);
+    },
+
+    /**
      * Reads up to and including the given string. Throws an error if that
      * string is not found.
      * @param {String} pattern The string to read.

--- a/tests/css/Parser.js
+++ b/tests/css/Parser.js
@@ -2138,6 +2138,21 @@ var YUITest = require("yuitest"),
             parser.parse(".foo {\n    color: #fff;\n}");
         },
 
+        "Test rule with custom property": function() {
+            var parser = new Parser({ strict: true });
+            parser.addListener("property", function(event) {
+                Assert.areEqual("--color-Foo_BAR", event.property.toString());
+                Assert.areEqual("#fff", event.value.toString());
+                Assert.areEqual(3, event.property.col, "Property column should be 3.");
+                Assert.areEqual(2, event.property.line, "Property line should be 2.");
+                Assert.areEqual(3, event.col, "Event column should be 3.");
+                Assert.areEqual(2, event.line, "Event line should be 2.");
+                Assert.areEqual(20, event.value.parts[0].col, "First part column should be 20.");
+                Assert.areEqual(2, event.value.parts[0].line, "First part line should be 2.");
+            });
+            parser.parse(".foo {\n  --color-Foo_BAR: #fff;\n}");
+        },
+
         "Test rule with star hack property": function() {
             var parser = new Parser({
                 strict: true,
@@ -2289,7 +2304,33 @@ var YUITest = require("yuitest"),
 
         name: "Invalid CSS Parsing Tests",
 
-        "Test parsing invalid celector": function() {
+        "Test parsing custom property typo": function() {
+            var error;
+            var parser = new Parser();
+            parser.addListener("error", function(e) {
+                error = e;
+            });
+            parser.parse("a:hover{\ncolor:red;\n==myFont:Helvetica;/*dropped*/;\nborder:0\n}");
+
+            Assert.areEqual("error", error.type);
+            Assert.areEqual(3, error.line);
+            Assert.areEqual(1, error.col);
+        },
+
+        "Test parsing invalid property": function() {
+            var error;
+            var parser = new Parser();
+            parser.addListener("error", function(e) {
+                error = e;
+            });
+            parser.parse("a:hover{\ncolor:red;\nfont::Helvetica;/*dropped*/;\nborder:0\n}");
+
+            Assert.areEqual("error", error.type);
+            Assert.areEqual(3, error.line);
+            Assert.areEqual(6, error.col);
+        },
+
+        "Test parsing invalid selector": function() {
             var error;
             var parser = new Parser();
             parser.addListener("error", function(e) {

--- a/tests/css/TokenStream.js
+++ b/tests/css/TokenStream.js
@@ -104,17 +104,25 @@ var YUITest = require("yuitest"),
         name: "Test for identifiers",
 
         patterns: {
-            "a":        [CSSTokens.IDENT],
-            "ab":       [CSSTokens.IDENT],
-            "a1":       [CSSTokens.IDENT],
-            "a_c":      [CSSTokens.IDENT],
-            "a-c":      [CSSTokens.IDENT],
-            "a90":      [CSSTokens.IDENT],
-            "a\\09":    [CSSTokens.IDENT],
-            "\\sa":     [CSSTokens.IDENT],
+            "a":            [CSSTokens.IDENT],
+            "ab":           [CSSTokens.IDENT],
+            "a1":           [CSSTokens.IDENT],
+            "a_c":          [CSSTokens.IDENT],
+            "a-c":          [CSSTokens.IDENT],
+            "a90":          [CSSTokens.IDENT],
+            "a\\09":        [CSSTokens.IDENT],
+            "\\sa":         [CSSTokens.IDENT],
+            "-foo":         [CSSTokens.IDENT],
+            "flex":         [CSSTokens.IDENT],
+            "-webkit-flex": [CSSTokens.IDENT],
 
             //not identifiers
-            "9a":       [CSSTokens.DIMENSION]
+            "9a":           [CSSTokens.DIMENSION],
+            "a+boo":        [CSSTokens.IDENT, CSSTokens.PLUS, CSSTokens.IDENT],
+
+            // existing parsing bugs
+            // "u+boo":        [CSSTokens.IDENT, CSSTokens.PLUS, CSSTokens.IDENT],
+            // "u+@":          [CSSTokens.IDENT, CSSTokens.PLUS, CSSTokens.CHAR],
         }
     }));
 
@@ -252,6 +260,7 @@ var YUITest = require("yuitest"),
         name : "Tests for Unicode ranges",
 
         patterns: {
+            "u+A5"          : [CSSTokens.UNICODE_RANGE],
             "U+A5"          : [CSSTokens.UNICODE_RANGE],
             "U+0-7F"        : [CSSTokens.UNICODE_RANGE],
             "U+590-5ff"     : [CSSTokens.UNICODE_RANGE],
@@ -263,8 +272,16 @@ var YUITest = require("yuitest"),
             "U+0??????"     : [CSSTokens.UNICODE_RANGE, CSSTokens.CHAR],
             "U+00-??"       : [CSSTokens.UNICODE_RANGE, CSSTokens.MINUS, CSSTokens.CHAR, CSSTokens.CHAR],
             "U+?1"          : [CSSTokens.UNICODE_RANGE, CSSTokens.NUMBER],
-            "U+"            : [CSSTokens.CHAR, CSSTokens.PLUS],
-            "U+00-J"        : [CSSTokens.UNICODE_RANGE, CSSTokens.IDENT]
+            "U+00-J"        : [CSSTokens.UNICODE_RANGE, CSSTokens.IDENT],
+
+            // Not unicode ranges
+            "U20"           : [CSSTokens.IDENT],
+
+            // existing parsing failures
+            // "u+"            : [CSSTokens.IDENT, CSSTokens.PLUS],
+            // "U+"            : [CSSTokens.IDENT, CSSTokens.PLUS],
+            // "U+@"           : [CSSTokens.IDENT, CSSTokens.PLUS, CSSTokens.CHAR],
+            // "U+U"           : [CSSTokens.IDENT, CSSTokens.PLUS, CSSTokens.IDENT],
         }
     }));
 
@@ -390,10 +407,12 @@ var YUITest = require("yuitest"),
             "1"         : [CSSTokens.NUMBER],
             "20.0"      : [CSSTokens.NUMBER],
             ".3"        : [CSSTokens.NUMBER],
+            "-0.3"      : [CSSTokens.NUMBER],
+            "+0"        : [CSSTokens.NUMBER],
+            "-.3"       : [CSSTokens.NUMBER],
+            "+.5"       : [CSSTokens.NUMBER],
 
             //invalid numbers
-            "-.3"       : [CSSTokens.MINUS, CSSTokens.NUMBER],
-            "+0"        : [CSSTokens.PLUS, CSSTokens.NUMBER],
             "-name"     : [CSSTokens.IDENT],
             "+name"     : [CSSTokens.PLUS, CSSTokens.IDENT]
 
@@ -434,7 +453,7 @@ var YUITest = require("yuitest"),
             "rgb(255,0,1)"      : [CSSTokens.FUNCTION, CSSTokens.NUMBER, CSSTokens.COMMA, CSSTokens.NUMBER, CSSTokens.COMMA, CSSTokens.NUMBER, CSSTokens.RPAREN],
             "counter(par-num,upper-roman)" : [CSSTokens.FUNCTION, CSSTokens.IDENT, CSSTokens.COMMA, CSSTokens.IDENT, CSSTokens.RPAREN],
             "calc(100% - 5px)"      : [CSSTokens.FUNCTION, CSSTokens.PERCENTAGE, CSSTokens.S, CSSTokens.MINUS, CSSTokens.S, CSSTokens.LENGTH, CSSTokens.RPAREN],
-            "calc((5em - 100%) / -2)" : [CSSTokens.FUNCTION, CSSTokens.LPAREN, CSSTokens.LENGTH, CSSTokens.S, CSSTokens.MINUS, CSSTokens.S, CSSTokens.PERCENTAGE, CSSTokens.RPAREN, CSSTokens.S, CSSTokens.SLASH, CSSTokens.S, CSSTokens.MINUS, CSSTokens.NUMBER, CSSTokens.RPAREN],
+            "calc((5em - 100%) / -2)" : [CSSTokens.FUNCTION, CSSTokens.LPAREN, CSSTokens.LENGTH, CSSTokens.S, CSSTokens.MINUS, CSSTokens.S, CSSTokens.PERCENTAGE, CSSTokens.RPAREN, CSSTokens.S, CSSTokens.SLASH, CSSTokens.S, CSSTokens.NUMBER, CSSTokens.RPAREN],
 
             //old-style IE filters - interpreted as bunch of tokens
             "alpha(opacity=50)" : [CSSTokens.FUNCTION, CSSTokens.IDENT, CSSTokens.EQUALS, CSSTokens.NUMBER, CSSTokens.RPAREN],

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -191,7 +191,7 @@ var YUITest = require("yuitest"),
         },
 
         error: {
-            "-0num": "Unexpected token '0num' at line 1, col 24."
+            "-0num": "Unexpected token '-0num' at line 1, col 23."
         }
     }));
 
@@ -755,7 +755,7 @@ var YUITest = require("yuitest"),
             "red",
             "#f00",
             "transparent",
-            "currentColor"
+            "currentColor",
         ],
 
         invalid: {
@@ -988,7 +988,7 @@ var YUITest = require("yuitest"),
 
         error: {
             "47Futura, sans-serif" : "Unexpected token '47Futura' at line 1, col 20.",
-            "-7Futura, sans-serif" : "Unexpected token '7Futura' at line 1, col 21.",
+            "-7Futura, sans-serif" : "Unexpected token '-7Futura' at line 1, col 20.",
             "Ahem!, sans-serif"    : "Expected RBRACE at line 1, col 24.",
             "test@foo, sans-serif" : "Expected RBRACE at line 1, col 24.",
             "#POUND, sans-serif"   : "Expected a hex color but found '#POUND' at line 1, col 20."


### PR DESCRIPTION
This should address [CSSLint/csslint/issues/720](https://github.com/CSSLint/csslint/issues/720).
Note: It doesn't add support for var(), only the custom properties themselves.