### PR TITLE
Add support for 'fr' units

### DIFF
--- a/src/css/Parser.js
+++ b/src/css/Parser.js
@@ -1876,8 +1876,8 @@ Parser.prototype = function() {
                 /*
                  * term
                  *   : unary_operator?
-                 *     [ NUMBER S* | PERCENTAGE S* | LENGTH S* | ANGLE S* |
-                 *       TIME S* | FREQ S* | function | ie_function ]
+                 *     [ NUMBER S* | PERCENTAGE S* | DIMENSION S* | LENGTH S* |
+                 *       ANGLE S* | TIME S* | FREQ S* | function | ie_function ]
                  *   | STRING S* | IDENT S* | URI S* | UNICODERANGE S* | hexcolor
                  *   ;
                  */
@@ -1922,9 +1922,9 @@ Parser.prototype = function() {
                     this._readWhitespace();
 
                 // see if there's a simple match
-                } else if (tokenStream.match([Tokens.NUMBER, Tokens.PERCENTAGE, Tokens.LENGTH,
-                    Tokens.ANGLE, Tokens.TIME,
-                    Tokens.FREQ, Tokens.STRING, Tokens.IDENT, Tokens.URI, Tokens.UNICODE_RANGE])) {
+                } else if (tokenStream.match([Tokens.NUMBER, Tokens.PERCENTAGE, Tokens.DIMENSION,
+                    Tokens.LENGTH, Tokens.ANGLE, Tokens.TIME, Tokens.FREQ, Tokens.STRING,
+                    Tokens.IDENT, Tokens.URI, Tokens.UNICODE_RANGE])) {
 
                     value = tokenStream.token().value;
                     if (unary === null) {

--- a/src/css/PropertyValuePart.js
+++ b/src/css/PropertyValuePart.js
@@ -62,7 +62,7 @@ function PropertyValuePart(text, line, col, optionalHint) {
                 break;
 
             case "fr":
-                this.type = "grid";
+                this.type = "flex";
                 break;
 
             case "deg":

--- a/src/css/Tokens.js
+++ b/src/css/Tokens.js
@@ -45,14 +45,10 @@ var Tokens = module.exports = [
     // important symbol
     { name: "IMPORTANT_SYM" },
 
-    // measurements
-    { name: "LENGTH" },
-    { name: "ANGLE" },
-    { name: "TIME" },
-    { name: "FREQ" },
-    { name: "DIMENSION" },
-    { name: "PERCENTAGE" },
-    { name: "NUMBER" },
+    // numeric
+    { name: "NUMBER" }, // https://www.w3.org/TR/css-syntax-3/#number-token-diagram
+    { name: "DIMENSION" }, // https://www.w3.org/TR/css-syntax-3/#dimension-token-diagram
+    { name: "PERCENTAGE" }, // https://www.w3.org/TR/css-syntax-3/#percentage-token-diagram
 
     // functions
     { name: "URI" },
@@ -108,6 +104,13 @@ var Tokens = module.exports = [
     /*
      * The following token names are not defined in any CSS specification but are used by the lexer.
      */
+
+    // TODO: Drop these as tokens, so they exist only as PropertyValueParts?
+    // subtypes of dimension: These are not tokens in CSS3 grammar.
+    { name: "LENGTH" }, // https://www.w3.org/TR/css3-values/#lengths
+    { name: "ANGLE" }, // https://www.w3.org/TR/css3-values/#angles
+    { name: "TIME" }, // https://www.w3.org/TR/css3-values/#time
+    { name: "FREQ" }, // https://www.w3.org/TR/css3-values/#frequency
 
     // not a real token, but useful for stupid IE filters
     { name: "IE_FUNCTION" },

--- a/tests/css/Parser.js
+++ b/tests/css/Parser.js
@@ -1037,6 +1037,32 @@ var YUITest = require("yuitest"),
             Assert.areEqual("ch", result.parts[0].units);
         },
 
+        testDimensionValueFr: function() {
+            var parser = new Parser();
+            var result = parser.parsePropertyValue("2fr");
+
+            Assert.isInstanceOf(parserlib.css.PropertyValue, result);
+            Assert.areEqual(1, result.parts.length);
+            Assert.areEqual("flex", result.parts[0].type);
+            Assert.areEqual(2, result.parts[0].value);
+            Assert.areEqual("fr", result.parts[0].units);
+        },
+
+        testDimensionValuePxAndFr: function() {
+            var parser = new Parser();
+            var result = parser.parsePropertyValue("100px 1fr");
+
+            Assert.isInstanceOf(parserlib.css.PropertyValue, result);
+            Assert.areEqual(2, result.parts.length);
+            Assert.areEqual("length", result.parts[0].type);
+            Assert.areEqual(100, result.parts[0].value);
+            Assert.areEqual("px", result.parts[0].units);
+            Assert.isInstanceOf(parserlib.css.PropertyValue, result);
+            Assert.areEqual("flex", result.parts[1].type);
+            Assert.areEqual(1, result.parts[1].value);
+            Assert.areEqual("fr", result.parts[1].units);
+        },
+
         testViewportRelativeHeightValue: function() {
             var parser = new Parser();
             var result = parser.parsePropertyValue("50vh");

--- a/tests/css/TokenStream.js
+++ b/tests/css/TokenStream.js
@@ -312,7 +312,7 @@ var YUITest = require("yuitest"),
     }));
 
     suite.add(new CSSTokenTestCase({
-        name : "Tests for Numbers",
+        name : "Tests for Numbers, Dimensions, and Percentages",
 
         patterns: {
 
@@ -321,7 +321,6 @@ var YUITest = require("yuitest"),
             "4px"       : [CSSTokens.LENGTH],
             "50.0PX"    : [CSSTokens.LENGTH],
             ".6Px"      : [CSSTokens.LENGTH],
-
 
             "7cm"       : [CSSTokens.LENGTH],
             "7CM"       : [CSSTokens.LENGTH],
@@ -363,7 +362,6 @@ var YUITest = require("yuitest"),
             "50.0CH"    : [CSSTokens.LENGTH],
             ".5cH"      : [CSSTokens.LENGTH],
 
-
             "5deg"       : [CSSTokens.ANGLE],
             "50.0DEG"    : [CSSTokens.ANGLE],
             ".5Deg"      : [CSSTokens.ANGLE],
@@ -394,6 +392,10 @@ var YUITest = require("yuitest"),
             "5khz"          : [CSSTokens.FREQ],
             "50.0KHZ"       : [CSSTokens.FREQ],
             ".5kHz"         : [CSSTokens.FREQ],
+
+            "1fr"           : [CSSTokens.DIMENSION],
+            "0fr"           : [CSSTokens.DIMENSION],
+            ".25fr"         : [CSSTokens.DIMENSION],
 
             "5ncz"          : [CSSTokens.DIMENSION],
             "50.0NCZ"       : [CSSTokens.DIMENSION],
@@ -505,6 +507,10 @@ var YUITest = require("yuitest"),
             //regular CSS functions
             "background: red;"       : [CSSTokens.IDENT, CSSTokens.COLON, CSSTokens.S, CSSTokens.IDENT, CSSTokens.SEMICOLON],
             "background-color: red;" : [CSSTokens.IDENT, CSSTokens.COLON, CSSTokens.S, CSSTokens.IDENT, CSSTokens.SEMICOLON],
+
+            //multiple value parts
+            "margin: 0 auto 10px;" : [CSSTokens.IDENT, CSSTokens.COLON, CSSTokens.S, CSSTokens.NUMBER, CSSTokens.S, CSSTokens.IDENT, CSSTokens.S, CSSTokens.LENGTH, CSSTokens.SEMICOLON],
+            "grid-template-columns: 100px 1fr max-content minmax(min-content, 1fr);" : [CSSTokens.IDENT, CSSTokens.COLON, CSSTokens.S, CSSTokens.LENGTH, CSSTokens.S, CSSTokens.DIMENSION, CSSTokens.S, CSSTokens.IDENT, CSSTokens.S, CSSTokens.FUNCTION, CSSTokens.IDENT,  CSSTokens.COMMA,  CSSTokens.S,  CSSTokens.DIMENSION,  CSSTokens.RPAREN, CSSTokens.SEMICOLON],
 
             "filter: progid:DXImageTransform.Microsoft.Wave(strength=100);": [CSSTokens.IDENT, CSSTokens.COLON, CSSTokens.S, CSSTokens.IE_FUNCTION, CSSTokens.IDENT, CSSTokens.EQUALS, CSSTokens.NUMBER, CSSTokens.RPAREN, CSSTokens.SEMICOLON]
 

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -87,6 +87,7 @@ var YUITest = require("yuitest"),
             underscoreHack: true
         });
         parser.parse(".foo { " + this.property + ":" + value + "}");
+        Assert.pass();
     };
 
 
@@ -187,11 +188,12 @@ var YUITest = require("yuitest"),
 
         invalid: {
             "1px" : "Expected ([ none | <single-animation-name> ]#) but found '1px'.",
-            "--invalid" : "Expected ([ none | <single-animation-name> ]#) but found '--invalid'."
+            "--invalid" : "Expected ([ none | <single-animation-name> ]#) but found '--invalid'.",
+            "-0num": "Expected ([ none | <single-animation-name> ]#) but found '-0num'.",
         },
 
         error: {
-            "-0num": "Unexpected token '-0num' at line 1, col 23."
+            "@foo": "Unexpected token '@foo' at line 1, col 23."
         }
     }));
 
@@ -981,14 +983,14 @@ var YUITest = require("yuitest"),
 
         invalid: {
             "--Futura, sans-serif"   : "Expected ([ <generic-family> | <family-name> ]#) but found '--Futura , sans-serif'.",
+            "47Futura, sans-serif"   : "Expected ([ <generic-family> | <family-name> ]#) but found '47Futura , sans-serif'.",
+            "-7Futura, sans-serif"   : "Expected ([ <generic-family> | <family-name> ]#) but found '-7Futura , sans-serif'.",
             "Red/Black, sans-serif"  : "Expected end of value but found '/'.",
             "'Lucida' Grande, sans-serif" : "Expected end of value but found 'Grande'.",
             "Hawaii 5-0, sans-serif" : "Expected end of value but found '5'."
         },
 
         error: {
-            "47Futura, sans-serif" : "Unexpected token '47Futura' at line 1, col 20.",
-            "-7Futura, sans-serif" : "Unexpected token '-7Futura' at line 1, col 20.",
             "Ahem!, sans-serif"    : "Expected RBRACE at line 1, col 24.",
             "test@foo, sans-serif" : "Expected RBRACE at line 1, col 24.",
             "#POUND, sans-serif"   : "Expected a hex color but found '#POUND' at line 1, col 20."
@@ -1058,6 +1060,15 @@ var YUITest = require("yuitest"),
             "normal", "ordinal", "slashed-zero", "lining-nums",
             "lining-nums proportional-nums diagonal-fractions ordinal",
             "oldstyle-nums tabular-nums stacked-fractions slashed-zero"
+        ]
+    }));
+
+    suite.add(new ValidationTestCase({
+        property: "grid-template-columns",
+
+        valid: [
+            "100px 1fr", "fit-content(40%)", "repeat(3, 200px)",
+            "100px 1fr max-content minmax(min-content, 1fr)"
         ]
     }));
 


### PR DESCRIPTION
This fixes #228 and the associated CSSLint/CSSLint#691. 

Renamed a method, and didn't remove existing dimension "tokens" to keep compatibility.
The reduction of parse failures is intentional.