### PR TITLE
Add support for 2 more valid writing-mode values

### DIFF
--- a/src/css/Properties.js
+++ b/src/css/Properties.js
@@ -488,7 +488,7 @@ var Properties = module.exports = {
     "word-break"                        : "normal | keep-all | break-all",
     "word-spacing"                      : "<length> | normal",
     "word-wrap"                         : "normal | break-word",
-    "writing-mode"                      : "horizontal-tb | vertical-rl | vertical-lr | lr-tb | rl-tb | tb-rl | bt-rl | tb-lr | bt-lr | lr-bt | rl-bt | lr | rl | tb",
+    "writing-mode"                      : "horizontal-tb | sideways-lr | sideways-rl | vertical-rl | vertical-lr | lr-tb | rl-tb | tb-rl | bt-rl | tb-lr | bt-lr | lr-bt | rl-bt | lr | rl | tb",
 
     // Z
     "z-index"                           : "<integer> | auto",

--- a/tests/css/Validation.js
+++ b/tests/css/Validation.js
@@ -1847,6 +1847,8 @@ var YUITest = require("yuitest"),
 
         valid: [
             "horizontal-tb",
+            "sideways-lr",
+            "sideways-rl",
             "vertical-rl",
             "vertical-lr",
             "lr-tb",


### PR DESCRIPTION
Added support for 2 more valid `writing-mode` values:
* `sideways-lr`
* `sideways-rl`

Reference spec: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/writing-mode